### PR TITLE
Fix edge case that causes infinite loop

### DIFF
--- a/Tiled/extensions/diablo-dun.js
+++ b/Tiled/extensions/diablo-dun.js
@@ -585,10 +585,10 @@ function findTransPolygon(trans, start) {
 	}
 
 	var cornerShapes = [0x1, 0x2, 0x4, 0x6, 0x7, 0x8, 0x9, 0xB, 0xD, 0xE];
-	var leftShapes   = [0x8, 0x9, 0xC, 0xD, 0xF];
-	var upShapes     = [0x4, 0x5, 0x6, 0x7, 0xF];
-	var rightShapes  = [0x1, 0x3, 0x9, 0xB, 0xF];
-	var downShapes   = [0x2, 0x6, 0xA, 0xE, 0xF];
+	var leftShapes   = [0x8, 0xC, 0xD];
+	var upShapes     = [0x4, 0x5, 0x7];
+	var rightShapes  = [0x1, 0x3, 0xB];
+	var downShapes   = [0x2, 0xA, 0xE];
 
 	var points = [];
 	while (points.length === 0 || points[0].x !== x || points[0].y !== y) {
@@ -597,14 +597,25 @@ function findTransPolygon(trans, start) {
 		if (cornerShapes.includes(shape))
 			points.push(Qt.point(x, y));
 
-		if (direction !== right && leftShapes.includes(shape))
+		// Movements are determined by traversing the polygon clockwise
+		if (leftShapes.includes(shape))
 			goLeft();
-		else if (direction !== down && upShapes.includes(shape))
+		else if (upShapes.includes(shape))
 			goUp();
-		else if (direction !== left && rightShapes.includes(shape))
+		else if (rightShapes.includes(shape))
 			goRight();
-		else if (direction !== up && downShapes.includes(shape))
+		else if (downShapes.includes(shape))
 			goDown();
+		else if (direction === left && shape === 0x6)
+			goUp();
+		else if (direction === up && shape === 0x9)
+			goRight();
+		else if (direction === right && shape === 0x6)
+			goDown();
+		else if (direction === down && shape === 0x9)
+			goLeft();
+		else
+			goRight();
 	}
 	points.push(Qt.point(x, y));
 


### PR DESCRIPTION
I reviewed the code now that it's not so late and I'm not so tired. I realized there were a couple shapes not being handled properly when traversing the edge of the polygon so I loaded up an old save file that I thought might be problematic ([1-798114450.dun.zip](https://github.com/diasurgical/modding-tools/files/15145137/1-798114450.dun.zip)). In doing so, I encountered an infinite loop, but not in the location I was expecting. I believe it's because of a gap at the south end of room 6 that you can see in the following screenshot.

![image](https://github.com/diasurgical/modding-tools/assets/9203145/249edcea-318a-4fcb-9000-60a61d84f44b)

I thought I had accounted for this before by implementing the logic to prevent a 180-degree turn, but that logic wasn't actually doing anything useful. Turns out it's easier to add special cases for shapes 6 and 9 so I just did that. The inclusion of shape F was similarly not doing anything useful so I got rid of it. The final "else go right" captures a rare but theoretically possible case where traversal starts on shape 9.