### PR TITLE
Generate polygon for room 0 if it is inside another polygon

### DIFF
--- a/Tiled/extensions/diablo-dun.js
+++ b/Tiled/extensions/diablo-dun.js
@@ -150,7 +150,7 @@ var dunMapFormat = {
 				var position = { x: x, y: y };
 				visitTransPolygon(trans, visited, position);
 
-				if (trans[x][y] === 0)
+				if (trans[x][y] === 0 && !isInsideAny(x, y, transparency.objects))
 					continue;
 				var poly = findTransPolygon(trans, position);
 				transparency.addObject(poly);
@@ -481,7 +481,7 @@ function applyTransparency(trans, width, height, obj) {
 	for (var y = 0; y < height; y++) {
 		for (var x = 0; x < width; x++) {
 			if (isInside(x, y, polygon)) {
-				if (parseInt(obj.name) > 1) {
+				if (parseInt(obj.name) >= 0) {
 					trans[x][y] = parseInt(obj.name);
 				} else {
 					trans[x][y] = 1;
@@ -629,6 +629,10 @@ function findTransPolygon(trans, start) {
 	object.shape = MapObject.Polygon;
 	object.polygon = points;
 	return object;
+}
+
+function isInsideAny(x, y, objects) {
+	return objects.some(object => isInside(x, y, object.polygon));
 }
 
 /**


### PR DESCRIPTION
For dungeon levels with transparency values of zero in the middle of a nonzero transparency region, we need to actually draw those zero regions. This provides a more accurate visual representation for transparency and also ensures that the transparency data remains stable when saving a dun file.

Here is what the dungeon level in question looks like with the "room 0" polygons.

![3295576287-13-423456353](https://github.com/user-attachments/assets/a959488a-e5da-4c85-9452-47ee91966074)
